### PR TITLE
Fixed C/C++ compilation issue on Windows with VS compiler.

### DIFF
--- a/svm_robust/libsvm-compact-0.1/matlab/make_dense.m
+++ b/svm_robust/libsvm-compact-0.1/matlab/make_dense.m
@@ -1,23 +1,45 @@
 % This make.m is for MATLAB and OCTAVE under Windows, Mac, and Unix
 
+CompFiles = { ... Files to compile
+    {'libsvmread.c'} ...
+    {'libsvmwrite.c'} ...
+    {'svmtrain.c'           '../svm.cpp' 'svm_model_matlab.c'} ...
+    {'svmpredict.c'         '../svm.cpp' 'svm_model_matlab.c'} ...
+    {'svmtrain_inplace.c'   '../svm.cpp' 'svm_model_matlab.c'} ...
+    {'svmpredict_inplace.c' '../svm.cpp' 'svm_model_matlab.c'} ...
+    };
+
+MEXOPTS = { ... Mex options
+    '-g' ...
+    '-largeArrayDims' ...
+    };
+
 try
-	Type = ver;
-	% This part is for OCTAVE
-	if(strcmp(Type(1).Name, 'Octave') == 1)
-		mex libsvmread.c
-		mex libsvmwrite.c
-		mex svmtrain.c ../svm.cpp svm_model_matlab.c
-		mex svmpredict.c ../svm.cpp svm_model_matlab.c
-	% This part is for MATLAB
-	% Add -largeArrayDims on 64-bit machines of MATLAB
-	else
-		mex -g CFLAGS="\$CFLAGS -D _DENSE_REP -std=c99" CXXFLAGS="\$CXXFLAGS -D _DENSE_REP" -largeArrayDims libsvmread.c
-		mex -g CFLAGS="\$CFLAGS -D _DENSE_REP -std=c99" CXXFLAGS="\$CXXFLAGS -D _DENSE_REP" -largeArrayDims libsvmwrite.c
-		mex -g CFLAGS="\$CFLAGS -D _DENSE_REP -std=c99" CXXFLAGS="\$CXXFLAGS -D _DENSE_REP" -largeArrayDims svmtrain.c ../svm.cpp svm_model_matlab.c
-		mex -g CFLAGS="\$CFLAGS -D _DENSE_REP -std=c99" CXXFLAGS="\$CXXFLAGS -D _DENSE_REP" -largeArrayDims svmtrain_inplace.c ../svm.cpp svm_model_matlab.c
-		mex -g CFLAGS="\$CFLAGS -D _DENSE_REP -std=c99" CXXFLAGS="\$CXXFLAGS -D _DENSE_REP" -largeArrayDims svmpredict.c ../svm.cpp svm_model_matlab.c
-		mex -g CFLAGS="\$CFLAGS -D _DENSE_REP -std=c99" CXXFLAGS="\$CXXFLAGS -D _DENSE_REP" -largeArrayDims svmpredict_inplace.c ../svm.cpp svm_model_matlab.c
-	end
+    Type = ver;
+    % This part is for OCTAVE
+    if (strcmp(Type(1).Name, 'Octave') == 1)
+        
+        for f = 1:4
+            mex( CompFiles{f}{:} )
+        end
+        
+    % This part is for MATLAB
+    % Add -largeArrayDims on 64-bit machines of MATLAB
+    else
+                
+        cc = mex.getCompilerConfigurations; % Get default compiler configurations used by the mex command
+        if ispc && strcmp(cc(1).Manufacturer, 'Microsoft')
+            FLAGS = {'COMPFLAGS="$COMPFLAGS /D _DENSE_REP"'};
+        else
+            FLAGS = {'CFLAGS="\$CFLAGS -D _DENSE_REP -std=c99"' ...
+                     'CXXFLAGS="\$CXXFLAGS -D _DENSE_REP"'};
+        end
+        
+        for f = 1:numel(CompFiles)
+            mex( MEXOPTS{:}, FLAGS{:}, CompFiles{f}{:} )
+        end
+        
+    end
 catch
-	fprintf('If make.m failes, please check README about detailed instructions.\n');
+    fprintf('If make.m fails, please check README about detailed instructions.\n');
 end

--- a/svm_robust/libsvm-compact-0.1/matlab/svmpredict.c
+++ b/svm_robust/libsvm-compact-0.1/matlab/svmpredict.c
@@ -32,7 +32,7 @@ void read_sparse_instance(const mxArray *prhs, int index, struct svm_node *x)
 	j = 0;
 	low = (int)jc[index], high = (int)jc[index+1];
 #ifdef _DENSE_REP
-	bzero(x.values,x.dim*sizeof(double));
+	memset(x.values, 0, x.dim*sizeof(double));
 	for(i=low;i<high;i++)
 #ifdef _FLOAT_REP
 		x.values[(int)ir[i]] = (float) samples[i];

--- a/svm_robust/libsvm-compact-0.1/matlab/svmtrain.c
+++ b/svm_robust/libsvm-compact-0.1/matlab/svmtrain.c
@@ -460,7 +460,7 @@ int read_problem_sparse(const mxArray *label_vec, const mxArray *instance_mat)
 	prob.x = Malloc(struct svm_node,prob.l);
 #ifndef _FLOAT_REP
 	x_space = Malloc(double, max_index*prob.l);
-	bzero(x_space,max_index*prob.l*sizeof(double));
+	memset(x_space, 0, max_index*prob.l*sizeof(double));
 #endif
 	
 	for(i=0;i<prob.l;i++)


### PR DESCRIPTION
There is an error thrown when compiling on Windows and using the Microsoft Visual C/C++ 2013 Professional compiler.
Incorrect flags are used for Windows compiler.
This also causes an error from deprecated bzero() non-standard C function (now replaced with memset()).